### PR TITLE
Switch to /bin/sh

### DIFF
--- a/Tools/src/checkstyle.sh
+++ b/Tools/src/checkstyle.sh
@@ -1,10 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/sh
 echo "Run checkstyle script"
 
 # run gofmt
 echo "Run 'gofmt'"
-unformatted=$(gofmt -l `pwd`/src/)
-if [[ -n $unformatted ]]; then
+unformatted=$(gofmt -l $(pwd)/src/)
+if [ -n "$unformatted" ]; then
 	echo >&2 "Error: Found files not formatted by gofmt"
 	for fi in $unformatted; do
 		echo >&2 $fi
@@ -15,11 +15,11 @@ fi
 
 # run goimports
 echo "Try update 'goimports'"
-GOPATH=`pwd`/Tools go get golang.org/x/tools/cmd/goimports
+GOPATH=$(pwd)/Tools go get golang.org/x/tools/cmd/goimports
 
 echo "Run 'goimports'"
-unformatted=$(Tools/bin/goimports -l `pwd`/src/)
-if [[ -n $unformatted ]]; then
+unformatted=$(Tools/bin/goimports -l $(pwd)/src/)
+if [ -n "$unformatted" ]; then
 	echo >&2 "Error: Found files not formatted by goimports"
 	for f in $unformatted; do
 		echo >&2 $f
@@ -29,5 +29,5 @@ if [[ -n $unformatted ]]; then
 fi
 
 echo "Run 'go vet'"
-ln -s `pwd` `pwd`/vendor/src/github.com/aws/SSMCLI
+ln -s $(pwd) $(pwd)/vendor/src/github.com/aws/SSMCLI
 go vet ./src/...


### PR DESCRIPTION
*Issue #, if available:*

#12

*Description of changes:*

Switches from `/usr/bin/env bash` to `/bin/sh`. There are no bashism in the script, so it doesn't need bash. Relying on bash breaks the build on vanilla Alpine Linux.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
