### PR TITLE
Use os.Stderr instead of os.Stdout with fmt.Fprintf()

### DIFF
--- a/src/datachannel/streaming.go
+++ b/src/datachannel/streaming.go
@@ -495,7 +495,7 @@ func (dataChannel *DataChannel) handleHandshakeComplete(log log.T, clientMessage
 		handshakeComplete.HandshakeTimeToComplete.Seconds())
 
 	if handshakeComplete.CustomerMessage != "" {
-		fmt.Fprintln(os.Stdout, handshakeComplete.CustomerMessage)
+		fmt.Fprintln(os.Stderr, handshakeComplete.CustomerMessage)
 	}
 
 	return err
@@ -763,9 +763,9 @@ func (dataChannel DataChannel) HandleChannelClosedMessage(log log.T, stopHandler
 
 	log.Infof("Exiting session with sessionId: %s with output: %s", sessionId, channelClosedMessage.Output)
 	if channelClosedMessage.Output == "" {
-		fmt.Fprintf(os.Stdout, "\n\nExiting session with sessionId: %s.\n\n", sessionId)
+		fmt.Fprintf(os.Stderr, "\n\nExiting session with sessionId: %s.\n\n", sessionId)
 	} else {
-		fmt.Fprintf(os.Stdout, "\n\nSessionId: %s : %s\n\n", sessionId, channelClosedMessage.Output)
+		fmt.Fprintf(os.Stderr, "\n\nSessionId: %s : %s\n\n", sessionId, channelClosedMessage.Output)
 	}
 
 	stopHandler()

--- a/src/sessionmanagerplugin-main/main.go
+++ b/src/sessionmanagerplugin-main/main.go
@@ -23,5 +23,5 @@ import (
 )
 
 func main() {
-	session.ValidateInputAndStartSession(os.Args, os.Stdout)
+	session.ValidateInputAndStartSession(os.Args, os.Stderr)
 }

--- a/src/sessionmanagerplugin/session/portsession/basicportforwarding.go
+++ b/src/sessionmanagerplugin/session/portsession/basicportforwarding.go
@@ -175,7 +175,7 @@ func (p *BasicPortForwarding) handleControlSignals(log log.T) {
 			if err := p.session.DataChannel.SendFlag(log, message.TerminateSession); err != nil {
 				log.Errorf("Failed to send TerminateSession flag: %v", err)
 			}
-			fmt.Fprintf(os.Stdout, "\n\nExiting session with sessionId: %s.\n\n", p.sessionId)
+			fmt.Fprintf(os.Stderr, "\n\nExiting session with sessionId: %s.\n\n", p.sessionId)
 			p.Stop()
 		} else {
 			p.session.TerminateSession(log)

--- a/src/sessionmanagerplugin/session/portsession/muxportforwarding.go
+++ b/src/sessionmanagerplugin/session/portsession/muxportforwarding.go
@@ -187,7 +187,7 @@ func (p *MuxPortForwarding) handleControlSignals(log log.T) {
 		if err := p.session.DataChannel.SendFlag(log, message.TerminateSession); err != nil {
 			log.Errorf("Failed to send TerminateSession flag: %v", err)
 		}
-		fmt.Fprintf(os.Stdout, "\n\nExiting session with sessionId: %s.\n\n", p.sessionId)
+		fmt.Fprintf(os.Stderr, "\n\nExiting session with sessionId: %s.\n\n", p.sessionId)
 		p.Stop()
 	}()
 }

--- a/src/sessionmanagerplugin/session/session.go
+++ b/src/sessionmanagerplugin/session/session.go
@@ -190,7 +190,7 @@ func ValidateInputAndStartSession(args []string, out io.Writer) {
 
 //Execute create data channel and start the session
 func (s *Session) Execute(log log.T) (err error) {
-	fmt.Fprintf(os.Stdout, "\nStarting session with SessionId: %s\n", s.SessionId)
+	fmt.Fprintf(os.Stderr, "\nStarting session with SessionId: %s\n", s.SessionId)
 
 	// sets the display mode
 	s.DisplayMode = sessionutil.NewDisplayMode(log)

--- a/src/sessionmanagerplugin/session/sessionhandler.go
+++ b/src/sessionmanagerplugin/session/sessionhandler.go
@@ -129,7 +129,7 @@ func (s *Session) ResumeSessionHandler(log log.T) (err error) {
 		return
 	} else if s.TokenValue == "" {
 		log.Debugf("Session: %s timed out", s.SessionId)
-		fmt.Fprintf(os.Stdout, "Session: %s timed out.\n", s.SessionId)
+		fmt.Fprintf(os.Stderr, "Session: %s timed out.\n", s.SessionId)
 		os.Exit(0)
 	}
 	s.DataChannel.GetWsChannel().SetChannelToken(s.TokenValue)

--- a/src/sessionmanagerplugin/session/sessionutil/sessionutil_windows.go
+++ b/src/sessionmanagerplugin/session/sessionutil/sessionutil_windows.go
@@ -70,7 +70,7 @@ func (d *DisplayMode) DisplayMessage(log log.T, message message.ClientMessage) {
 	// refer - https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-writefile
 	if err = windows.WriteFile(d.handle, message.Payload, done, nil); err != nil {
 		log.Errorf("error occurred while writing to file: %v", err)
-		fmt.Fprintf(os.Stdout, "\nError getting the output. %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "\nError getting the output. %s\n", err.Error())
 		os.Exit(0)
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

In the latest version (1.2.279.0), fmt.Fprintf() writes to `os.Stdout` in any context. In some cases, this can lead to unexpected behaviors of the application which works with Session Manager.

In my case, [paramiko](https://github.com/paramiko/paramiko), a SSH implementaiton for Python, reads the output (e.g. [session.go:193](https://github.com/aws/session-manager-plugin/blob/2937bbc05085c5659507efb467f289989debcd6a/src/sessionmanagerplugin/session/session.go#L193)) of session-manager-plugin from stdout during the wait for SSH banner.

As the result, paramiko breaks out the loop of wating for SSH banner, and the banner_timeout parameter is reset to paramiko's default (e.g. [transport.py:2201](https://github.com/paramiko/paramiko/blob/a598ca14d6451343c69be97e0e1c65eb15c0e607/paramiko/transport.py#L2201)). For this reason, I cannot connect to a server via SSH through the tunnel of Session Manager in the environment that takes a long time to establish the connection.

So, if possible, I would like to make a change so that fmt.Fprint() writes to stderr.

*Additional Information:*

[A similar topic](https://github.com/aws/amazon-ssm-agent/issues/358) is being discussed in the repository of aws-ssm-agent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
