### PR TITLE
Add custom endpoint support

### DIFF
--- a/src/sessionmanagerplugin/session/session.go
+++ b/src/sessionmanagerplugin/session/session.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -205,7 +206,8 @@ func ValidateInputAndStartSession(args []string, out io.Writer) {
 				if strings.HasSuffix(ssmmsgEndpoint, ".vpce.amazonaws.com") {
 					// Looks like a legit endpoint, patch the WSS url
 					fmt.Printf("Custom endpoint detected %s\n", ssmmsgEndpoint)
-					session.StreamUrl = strings.Replace(streamUrl, "ssmmessages.eu-west-1.amazonaws.com", ssmmsgEndpoint, -1)
+					m := regexp.MustCompile(`ssmmessages.*amazonaws.com`)
+					session.StreamUrl = m.ReplaceAllString(streamUrl, ssmmsgEndpoint)
 				}
 			}
 		}


### PR DESCRIPTION
#Why this PR
This PR adds custom SSM Messages endpoint support. The involved mechanism could be extended to KMS and SSM itself, but my current need is SSM Messages across WSS protocol.

AWS CLI does not support multiple endpoint point, so, the sole one handled by the CLI is SSM endpoint. For this plugin, 2 others endpoints are used : SSM Messages and KMS.

This PR adds a way to communicate the SSM messages endpoint from the CLI to this plugin without updating the AWS CLI.

#Description of changes
The rendez-vous place for these endpoints is the AWS configuration file using the given profile. So the `session.go` has been updated to retrieve the endpoint from the configuration file. To get this attribute I use "aws configure get aws_ssmmessages_endpoint --profile $GIVEN_PROFILE`

So, the common usage includes an additionnal (optional) `aws configure set` call:
```bash
aws configure set --profile PROFILE aws_access_key_id ...
...
aws configure set --profile PROFILE aws_ssmmessages_endpoint vpce-123-aaa.ssmmessages.eu-west-1.vpce.amazonaws.com 
aws ssm start-session --profile PROFILE --target i-123 --document-name AWS-StartPortForwardingSession --parameters "localPortNumber=53389,portNumber=3389"
```

All the changes are located in `session.go` file:
- Checks there is a profile
- Invokes the `aws configure` command to get the custom endpoint
- Checks the format of this endpoint
- Patches the WSS url accordingly to the endpoint

Disclaimer: being novice in Go, I have not written any test but I could to complete this PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
