### PR TITLE
Upgrade to go 1.16 and add darwin-arm64 support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.16
 
 RUN apt -y update && apt -y upgrade && apt -y install rpm tar gzip wget zip && apt clean all
 

--- a/Tools/src/create_darwin_bundle_plugin.sh
+++ b/Tools/src/create_darwin_bundle_plugin.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 ARCH=$1
-if [ -z "${ARCH}" ]; then
-    echo "Usage: $0 [${ARCH}|arm64]"
-    exit 1
-elif [ ${ARCH} -ne "amd64" -o ${ARCH} -ne "arm64" ]; then
-    echo "Usage: $0 [${ARCH}|arm64]"
-    exit 1
-fi
+case $ARCH in
+    amd64 | arm64)
+        ;;
+    *)
+        echo "Usage: $0 [amd64|arm64]"
+        exit 1
+esac
 
 echo "**********************************************"
 echo "Creating bundle zip file Mac OS X $ARCH Plugin"

--- a/Tools/src/create_darwin_bundle_plugin.sh
+++ b/Tools/src/create_darwin_bundle_plugin.sh
@@ -1,38 +1,49 @@
 #!/usr/bin/env bash
+
+ARCH=$1
+if [ -z "${ARCH}" ]; then
+    echo "Usage: $0 [${ARCH}|arm64]"
+    exit 1
+elif [ ${ARCH} -ne "amd64" -o ${ARCH} -ne "arm64" ]; then
+    echo "Usage: $0 [${ARCH}|arm64]"
+    exit 1
+fi
+
 echo "**********************************************"
-echo "Creating bundle zip file Mac OS X amd64 Plugin"
+echo "Creating bundle zip file Mac OS X $ARCH Plugin"
 echo "**********************************************"
 
-rm -rf ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle
+
+rm -rf ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle
 
 echo "Creating bundle workspace"
 
-mkdir -p ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/bin
+mkdir -p ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/bin
 
 echo "Copying application files"
 
-cp ${GO_SPACE}/LICENSE ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/LICENSE
-cp ${GO_SPACE}/NOTICE ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/NOTICE
-cp ${GO_SPACE}/THIRD-PARTY ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/THIRD-PARTY
-cp ${GO_SPACE}/README.md ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/README.md
-cp ${GO_SPACE}/RELEASENOTES.md ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/RELEASENOTES.md
-cp ${GO_SPACE}/VERSION ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/VERSION
-cp ${GO_SPACE}/bin/darwin_amd64_plugin/session-manager-plugin ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/bin/session-manager-plugin
-cp ${GO_SPACE}/seelog_unix.xml ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/seelog.xml.template
+cp ${GO_SPACE}/LICENSE ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/LICENSE
+cp ${GO_SPACE}/NOTICE ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/NOTICE
+cp ${GO_SPACE}/THIRD-PARTY ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/THIRD-PARTY
+cp ${GO_SPACE}/README.md ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/README.md
+cp ${GO_SPACE}/RELEASENOTES.md ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/RELEASENOTES.md
+cp ${GO_SPACE}/VERSION ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/VERSION
+cp ${GO_SPACE}/bin/darwin_${ARCH}_plugin/session-manager-plugin ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/bin/session-manager-plugin
+cp ${GO_SPACE}/seelog_unix.xml ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/seelog.xml.template
 
 echo "Copying install script"
 
-cp ${GO_SPACE}/Tools/src/darwin/install ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/install
-chmod 755 ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/install;
+cp ${GO_SPACE}/Tools/src/darwin/install ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/install
+chmod 755 ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/install;
 
-cd ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/bin/; strip --strip-unneeded session-manager-plugin; cd ~-
+cd ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle/bin/; strip --strip-unneeded session-manager-plugin; cd ~-
 
 echo "Creating the bundle zip file"
 
-if [ -f ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle.zip ]
+if [ -f ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle.zip ]
 then
-    rm ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle.zip
+    rm ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle.zip
 fi
 
-cd ${GO_SPACE}/bin/darwin_amd64_plugin;
-zip -r ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle.zip ./sessionmanager-bundle
+cd ${GO_SPACE}/bin/darwin_${ARCH}_plugin;
+zip -r ${GO_SPACE}/bin/darwin_${ARCH}_plugin/sessionmanager-bundle.zip ./sessionmanager-bundle

--- a/makefile
+++ b/makefile
@@ -17,11 +17,11 @@ checkstyle::
 #   Run checkstyle script
 	$(GO_SPACE)/Tools/src/checkstyle.sh
 
-build:: build-linux-amd64 build-linux-386 build-arm build-arm64 build-darwin-amd64 build-windows-amd64 build-windows-386
+build:: build-linux-amd64 build-linux-386 build-arm build-arm64 build-darwin-amd64 build-darwin-arm64 build-windows-amd64 build-windows-386
 
 prepack:: prepack-linux-amd64 prepack-linux-386 prepack-linux-arm64 prepack-windows-386 prepack-windows-amd64
 
-package:: create-package-folder package-rpm-amd64 package-rpm-386 package-rpm-arm64 package-deb-amd64 package-deb-386 package-deb-arm package-deb-arm64 package-darwin-amd64 package-win-386 package-win-amd64
+package:: create-package-folder package-rpm-amd64 package-rpm-386 package-rpm-arm64 package-deb-amd64 package-deb-386 package-deb-arm package-deb-arm64 package-darwin-amd64 package-darwin-arm64 package-win-386 package-win-amd64
 
 release:: clean checkstyle release-test pre-release build prepack package copy-package-dependencies
 
@@ -115,6 +115,14 @@ build-darwin-amd64: checkstyle copy-src pre-build
 	GOOS=darwin GOARCH=amd64 $(GO_BUILD) -ldflags "-s -w" -o $(GO_SPACE)/bin/darwin_amd64_plugin/session-manager-plugin -v \
 		$(GO_SPACE)/src/sessionmanagerplugin-main/main.go
 	GOOS=darwin GOARCH=amd64 $(GO_BUILD) -ldflags "-s -w" -o $(GO_SPACE)/bin/darwin_amd64/ssmcli -v \
+		$(GO_SPACE)/src/ssmcli-main/main.go
+
+.PHONY: build-darwin-arm64
+build-darwin-arm64: checkstyle copy-src pre-build
+	@echo "Build for darwin platform"
+	GOOS=darwin GOARCH=arm64 $(GO_BUILD) -ldflags "-s -w" -o $(GO_SPACE)/bin/darwin_amd64_plugin/session-manager-plugin -v \
+		$(GO_SPACE)/src/sessionmanagerplugin-main/main.go
+	GOOS=darwin GOARCH=arm64 $(GO_BUILD) -ldflags "-s -w" -o $(GO_SPACE)/bin/darwin_amd64/ssmcli -v \
     		$(GO_SPACE)/src/ssmcli-main/main.go
 
 .PHONY: build-windows-amd64
@@ -233,7 +241,11 @@ package-deb-arm64: create-package-folder
 
 .PHONY: package-darwin-amd64
 package-darwin-amd64:
-	$(GO_SPACE)/Tools/src/create_darwin_bundle_plugin.sh
+	$(GO_SPACE)/Tools/src/create_darwin_bundle_plugin.sh amd64
+
+.PHONY: package-darwin-arm64
+package-darwin-arm64:
+	$(GO_SPACE)/Tools/src/create_darwin_bundle_plugin.sh arm64
 
 .PHONY: package-win-386
 package-win-386: create-package-folder

--- a/makefile
+++ b/makefile
@@ -122,9 +122,9 @@ build-darwin-amd64: checkstyle copy-src pre-build
 .PHONY: build-darwin-arm64
 build-darwin-arm64: checkstyle copy-src pre-build
 	@echo "Build for darwin platform"
-	GOOS=darwin GOARCH=arm64 $(GO_BUILD) -ldflags "-s -w" -o $(GO_SPACE)/bin/darwin_amd64_plugin/session-manager-plugin -v \
+	GOOS=darwin GOARCH=arm64 $(GO_BUILD) -ldflags "-s -w" -o $(GO_SPACE)/bin/darwin_arm64_plugin/session-manager-plugin -v \
 		$(GO_SPACE)/src/sessionmanagerplugin-main/main.go
-	GOOS=darwin GOARCH=arm64 $(GO_BUILD) -ldflags "-s -w" -o $(GO_SPACE)/bin/darwin_amd64/ssmcli -v \
+	GOOS=darwin GOARCH=arm64 $(GO_BUILD) -ldflags "-s -w" -o $(GO_SPACE)/bin/darwin_arm64/ssmcli -v \
     		$(GO_SPACE)/src/ssmcli-main/main.go
 
 .PHONY: build-windows-amd64

--- a/makefile
+++ b/makefile
@@ -1,5 +1,6 @@
 COPY := cp -p
 GO_BUILD := go build -i
+GO111MODULE := auto
 
 # Default build configuration, can be overridden at build time.
 GOARCH?=$(shell go env GOARCH)
@@ -12,6 +13,7 @@ GOPATH:=$(GOTEMPPATH):$(GO_SPACE)/vendor:$(GOPATH)
 
 export GOPATH
 export GO_SPACE
+export GO111MODULE
 
 checkstyle::
 #   Run checkstyle script

--- a/src/log/log_unix.go
+++ b/src/log/log_unix.go
@@ -11,6 +11,7 @@
 // either express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build darwin || freebsd || linux || netbsd || openbsd
 // +build darwin freebsd linux netbsd openbsd
 
 // Package log is used to initialize logger

--- a/src/log/log_windows.go
+++ b/src/log/log_windows.go
@@ -11,6 +11,7 @@
 // either express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build windows
 // +build windows
 
 // Package log is used to initialize logger

--- a/src/sessionmanagerplugin/session/sessionutil/control_signals_unix.go
+++ b/src/sessionmanagerplugin/session/sessionutil/control_signals_unix.go
@@ -11,6 +11,7 @@
 // either express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build darwin || freebsd || linux || netbsd || openbsd
 // +build darwin freebsd linux netbsd openbsd
 
 // Package sessionutil contains utility methods required to start session.

--- a/src/sessionmanagerplugin/session/sessionutil/control_signals_windows.go
+++ b/src/sessionmanagerplugin/session/sessionutil/control_signals_windows.go
@@ -11,6 +11,7 @@
 // either express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build windows
 // +build windows
 
 // Package sessionutil contains utility methods required to start session.

--- a/src/sessionmanagerplugin/session/sessionutil/sessionutil_unix.go
+++ b/src/sessionmanagerplugin/session/sessionutil/sessionutil_unix.go
@@ -11,6 +11,7 @@
 // either express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build darwin || freebsd || linux || netbsd || openbsd
 // +build darwin freebsd linux netbsd openbsd
 
 // Package sessionutil provides utility for sessions.

--- a/src/sessionmanagerplugin/session/sessionutil/sessionutil_windows.go
+++ b/src/sessionmanagerplugin/session/sessionutil/sessionutil_windows.go
@@ -11,6 +11,7 @@
 // either express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build windows
 // +build windows
 
 // Package sessionutil provides utility for sessions.

--- a/src/sessionmanagerplugin/session/shellsession/shellsession_unix.go
+++ b/src/sessionmanagerplugin/session/shellsession/shellsession_unix.go
@@ -11,6 +11,7 @@
 // either express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build darwin || freebsd || linux || netbsd || openbsd
 // +build darwin freebsd linux netbsd openbsd
 
 // Package shellsession starts shell session.

--- a/src/sessionmanagerplugin/session/shellsession/shellsession_windows.go
+++ b/src/sessionmanagerplugin/session/shellsession/shellsession_windows.go
@@ -11,6 +11,7 @@
 // either express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build windows
 // +build windows
 
 // Package shellsession starts shell session.


### PR DESCRIPTION
go 1.16 is required for darwin-arm64 support. I've added this to the build process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
