### PR TITLE
added darwin arm64

### DIFF
--- a/Tools/src/create_darwin_amd64_bundle_plugin.sh
+++ b/Tools/src/create_darwin_amd64_bundle_plugin.sh
@@ -25,7 +25,7 @@ echo "Copying install script"
 cp ${GO_SPACE}/Tools/src/darwin/install ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/install
 chmod 755 ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/install;
 
-cd ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/bin/; strip --strip-unneeded session-manager-plugin; cd ~-
+cd ${GO_SPACE}/bin/darwin_amd64_plugin/sessionmanager-bundle/bin/; strip session-manager-plugin; cd ~-
 
 echo "Creating the bundle zip file"
 

--- a/Tools/src/create_darwin_arm64_bundle_plugin.sh
+++ b/Tools/src/create_darwin_arm64_bundle_plugin.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+echo "**********************************************"
+echo "Creating bundle zip file Mac OS X arm64 Plugin"
+echo "**********************************************"
+
+rm -rf ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle
+
+echo "Creating bundle workspace"
+
+mkdir -p ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/bin
+
+echo "Copying application files"
+
+cp ${GO_SPACE}/LICENSE ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/LICENSE
+cp ${GO_SPACE}/NOTICE ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/NOTICE
+cp ${GO_SPACE}/THIRD-PARTY ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/THIRD-PARTY
+cp ${GO_SPACE}/README.md ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/README.md
+cp ${GO_SPACE}/RELEASENOTES.md ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/RELEASENOTES.md
+cp ${GO_SPACE}/VERSION ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/VERSION
+cp ${GO_SPACE}/bin/darwin_arm64_plugin/session-manager-plugin ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/bin/session-manager-plugin
+cp ${GO_SPACE}/seelog_unix.xml ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/seelog.xml.template
+
+echo "Copying install script"
+
+cp ${GO_SPACE}/Tools/src/darwin/install ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/install
+chmod 755 ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/install;
+
+cd ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle/bin/; strip session-manager-plugin; cd ~-
+
+echo "Creating the bundle zip file"
+
+if [ -f ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle.zip ]
+then
+    rm ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle.zip
+fi
+
+cd ${GO_SPACE}/bin/darwin_arm64_plugin;
+zip -r ${GO_SPACE}/bin/darwin_arm64_plugin/sessionmanager-bundle.zip ./sessionmanager-bundle

--- a/Tools/src/darwin/install
+++ b/Tools/src/darwin/install
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import optparse
 import os
 import shutil

--- a/makefile
+++ b/makefile
@@ -16,12 +16,11 @@ export GO_SPACE
 checkstyle::
 #   Run checkstyle script
 	$(GO_SPACE)/Tools/src/checkstyle.sh
-
-build:: build-linux-amd64 build-linux-386 build-arm build-arm64 build-darwin-amd64 build-windows-amd64 build-windows-386
+build:: build-linux-amd64 build-linux-386 build-arm build-arm64 build-darwin-arm64 build-darwin-amd64 build-windows-amd64 build-windows-386
 
 prepack:: prepack-linux-amd64 prepack-linux-386 prepack-linux-arm64 prepack-windows-386 prepack-windows-amd64
 
-package:: create-package-folder package-rpm-amd64 package-rpm-386 package-rpm-arm64 package-deb-amd64 package-deb-386 package-deb-arm package-deb-arm64 package-darwin-amd64 package-win-386 package-win-amd64
+package:: create-package-folder package-rpm-amd64 package-rpm-386 package-rpm-arm64 package-deb-amd64 package-deb-386 package-deb-arm package-deb-arm64 package-darwin-arm64 package-darwin-amd64 package-win-386 package-win-amd64
 
 release:: clean checkstyle release-test pre-release build prepack package copy-package-dependencies
 
@@ -108,6 +107,13 @@ build-arm64: checkstyle copy-src pre-build
 	GOOS=linux GOARCH=arm64 $(GO_BUILD) -ldflags "-s -w -extldflags=-Wl,-z,now,-z,relro,-z,defs" -o $(GO_SPACE)/bin/linux_arm64_plugin/session-manager-plugin -v \
 		$(GO_SPACE)/src/sessionmanagerplugin-main/main.go
 
+.PHONY: build-darwin-arm64
+build-darwin-arm64: checkstyle copy-src pre-build
+	@echo "Build for darwin platform"
+	GOOS=darwin GOARCH=arm64 $(GO_BUILD) -ldflags "-s -w" -o $(GO_SPACE)/bin/darwin_arm64_plugin/session-manager-plugin -v \
+		$(GO_SPACE)/src/sessionmanagerplugin-main/main.go
+	GOOS=darwin GOARCH=arm64 $(GO_BUILD) -ldflags "-s -w" -o $(GO_SPACE)/bin/darwin_arm64/ssmcli -v \
+    		$(GO_SPACE)/src/ssmcli-main/main.go
 
 .PHONY: build-darwin-amd64
 build-darwin-amd64: checkstyle copy-src pre-build
@@ -231,9 +237,13 @@ package-deb-arm: create-package-folder
 package-deb-arm64: create-package-folder
 	$(GO_SPACE)/Tools/src/create_deb_arm64_plugin.sh
 
+.PHONY: package-darwin-arm64
+package-darwin-arm64:
+	$(GO_SPACE)/Tools/src/create_darwin_arm64_bundle_plugin.sh
+
 .PHONY: package-darwin-amd64
 package-darwin-amd64:
-	$(GO_SPACE)/Tools/src/create_darwin_bundle_plugin.sh
+	$(GO_SPACE)/Tools/src/create_darwin_amd64_bundle_plugin.sh
 
 .PHONY: package-win-386
 package-win-386: create-package-folder


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/session-manager-plugin/issues/26

*Description of changes:*
Added `Tools/src/create_darwin_arm64_bundle_plugin.sh` as a carbon copy of `Tools/src/create_darwin_bundle_plugin.sh`, except all instances of `amd64` are replaced with `arm64`.
Moved the above script to `Tools/src/create_darwin_amd64_bundle_plugin.sh` to help differentiate between the two bundlers.

Added targets for the `arm64` architecture to the makefile above every instance of the `amd64` build steps for darwin.

Renamed the bundler script in the makefile to use the new bundler script for `amd64` architecture


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


Release for people that need to use it right now (note, my gofmt did not work, and govet is super annoyed at this, so i just turned that off before i built):
https://github.com/bleepbloopsify/session-manager-plugin/releases/tag/dev.macos.arm64
