### PR TITLE
Allow setting of the local listener address

### DIFF
--- a/src/sessionmanagerplugin/session/portsession/basicportforwarding.go
+++ b/src/sessionmanagerplugin/session/portsession/basicportforwarding.go
@@ -143,6 +143,10 @@ func (p *BasicPortForwarding) startLocalConn(log log.T) (err error) {
 // startLocalListener starts a local listener to given address
 func (p *BasicPortForwarding) startLocalListener(log log.T, portNumber string) (listener net.Listener, err error) {
 	var displayMessage string
+	localListenerAddress := p.portParameters.LocalListenerAddress
+	if localListenerAddress == "" {
+		localListenerAddress = "localhost"
+	}
 	switch p.portParameters.LocalConnectionType {
 	case "unix":
 		if listener, err = getNewListener(p.portParameters.LocalConnectionType, p.portParameters.LocalUnixSocket); err != nil {
@@ -150,7 +154,7 @@ func (p *BasicPortForwarding) startLocalListener(log log.T, portNumber string) (
 		}
 		displayMessage = fmt.Sprintf("Unix socket %s opened for sessionId %s.", p.portParameters.LocalUnixSocket, p.sessionId)
 	default:
-		if listener, err = getNewListener("tcp", "localhost:"+portNumber); err != nil {
+		if listener, err = getNewListener("tcp", localListenerAddress+":"+portNumber); err != nil {
 			return
 		}
 		// get port number the TCP listener opened

--- a/src/sessionmanagerplugin/session/portsession/muxportforwarding.go
+++ b/src/sessionmanagerplugin/session/portsession/muxportforwarding.go
@@ -242,7 +242,11 @@ func (p *MuxPortForwarding) handleClientConnections(log log.T, ctx context.Conte
 		if p.portParameters.LocalPortNumber == "" {
 			localPortNumber = "0"
 		}
-		if listener, err = net.Listen("tcp", "localhost:"+localPortNumber); err != nil {
+		localListenerAddress := p.portParameters.LocalListenerAddress
+		if localListenerAddress == "" {
+			localListenerAddress = "localhost"
+		}
+		if listener, err = net.Listen("tcp", localListenerAddress+":"+localPortNumber); err != nil {
 			return err
 		}
 		p.portParameters.LocalPortNumber = strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)

--- a/src/sessionmanagerplugin/session/portsession/portsession.go
+++ b/src/sessionmanagerplugin/session/portsession/portsession.go
@@ -42,11 +42,12 @@ type IPortSession interface {
 }
 
 type PortParameters struct {
-	PortNumber          string `json:"portNumber"`
-	LocalPortNumber     string `json:"localPortNumber"`
-	LocalUnixSocket     string `json:"localUnixSocket"`
-	LocalConnectionType string `json:"localConnectionType"`
-	Type                string `json:"type"`
+	PortNumber           string `json:"portNumber"`
+	LocalPortNumber      string `json:"localPortNumber"`
+	LocalUnixSocket      string `json:"localUnixSocket"`
+	LocalConnectionType  string `json:"localConnectionType"`
+	LocalListenerAddress string `json:"localListenerAddress"`
+	Type                 string `json:"type"`
 }
 
 func init() {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/session-manager-plugin/issues/14 (slightly related)

*Description of changes:*

1. What:
This change introduces the ability to change the listener **address**, under which the port forwarding will listen. The default of `localhost` is kept.

2. Why:
I am using a `PortForwardingSession`, which runs inside a [GitLab CI Service](https://docs.gitlab.com/ee/ci/services/). This allows me to abstract the forwarding logic away, and have it re-usable. However, since the forwarding session is not running "locally" anymore, it needs to be accessible from outside the service. With a listener address of `localhost`, this is not possible. I am successfully using `0.0.0.0` akin to whats written in  https://github.com/aws/session-manager-plugin/issues/14, and this works flawlessly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
