### PR TITLE
Add quiet mode

### DIFF
--- a/src/datachannel/streaming.go
+++ b/src/datachannel/streaming.go
@@ -21,8 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
-	"os"
 	"reflect"
 	"sync"
 	"time"
@@ -115,6 +115,9 @@ type DataChannel struct {
 
 	// AgentVersion received during handshake
 	agentVersion string
+
+	// Out is where user ssm plugin logs go
+	Out io.Writer
 }
 
 type ListMessageBuffer struct {
@@ -510,7 +513,7 @@ func (dataChannel *DataChannel) handleHandshakeComplete(log log.T, clientMessage
 		handshakeComplete.HandshakeTimeToComplete.Seconds())
 
 	if handshakeComplete.CustomerMessage != "" {
-		fmt.Fprintln(os.Stdout, handshakeComplete.CustomerMessage)
+		fmt.Fprintln(dataChannel.Out, handshakeComplete.CustomerMessage)
 	}
 
 	return err
@@ -783,9 +786,9 @@ func (dataChannel DataChannel) HandleChannelClosedMessage(log log.T, stopHandler
 
 	log.Infof("Exiting session with sessionId: %s with output: %s", sessionId, channelClosedMessage.Output)
 	if channelClosedMessage.Output == "" {
-		fmt.Fprintf(os.Stdout, "\n\nExiting session with sessionId: %s.\n\n", sessionId)
+		fmt.Fprintf(dataChannel.Out, "\n\nExiting session with sessionId: %s.\n\n", sessionId)
 	} else {
-		fmt.Fprintf(os.Stdout, "\n\nSessionId: %s : %s\n\n", sessionId, channelClosedMessage.Output)
+		fmt.Fprintf(dataChannel.Out, "\n\nSessionId: %s : %s\n\n", sessionId, channelClosedMessage.Output)
 	}
 
 	stopHandler()

--- a/src/sessionmanagerplugin-main/main.go
+++ b/src/sessionmanagerplugin-main/main.go
@@ -22,6 +22,14 @@ import (
 	_ "github.com/aws/session-manager-plugin/src/sessionmanagerplugin/session/shellsession"
 )
 
+var out = os.Stdout
+
+func init() {
+	if quietStr := os.Getenv("AWS_SSM_QUIET"); quietStr == "true" || quietStr == "1" {
+		out = os.Stderr
+	}
+}
+
 func main() {
-	session.ValidateInputAndStartSession(os.Args, os.Stdout)
+	session.ValidateInputAndStartSession(os.Args, out)
 }

--- a/src/sessionmanagerplugin/session/portsession/basicportforwarding_test.go
+++ b/src/sessionmanagerplugin/session/portsession/basicportforwarding_test.go
@@ -48,6 +48,7 @@ func TestSetSessionHandlers(t *testing.T) {
 		Session:        mockSession,
 		portParameters: PortParameters{PortNumber: "22", Type: "LocalPortForwarding"},
 		portSessionType: &BasicPortForwarding{
+			out:            os.Stdout,
 			session:        mockSession,
 			portParameters: PortParameters{PortNumber: "22", Type: "LocalPortForwarding"},
 		},
@@ -84,6 +85,7 @@ func TestStartSessionTCPLocalPortFromDocument(t *testing.T) {
 		Session:        getSessionMock(),
 		portParameters: PortParameters{PortNumber: "22", Type: "LocalPortForwarding", LocalPortNumber: "54321"},
 		portSessionType: &BasicPortForwarding{
+			out:            os.Stdout,
 			session:        getSessionMock(),
 			portParameters: PortParameters{PortNumber: "22", Type: "LocalPortForwarding"},
 		},
@@ -101,6 +103,7 @@ func TestStartSessionTCPAcceptFailed(t *testing.T) {
 		Session:        getSessionMock(),
 		portParameters: PortParameters{PortNumber: "22", Type: "LocalPortForwarding"},
 		portSessionType: &BasicPortForwarding{
+			out:            os.Stdout,
 			session:        getSessionMock(),
 			portParameters: PortParameters{PortNumber: "22", Type: "LocalPortForwarding"},
 		},
@@ -117,6 +120,7 @@ func TestStartSessionTCPConnectFailed(t *testing.T) {
 		Session:        getSessionMock(),
 		portParameters: PortParameters{PortNumber: "22", Type: "LocalPortForwarding"},
 		portSessionType: &BasicPortForwarding{
+			out:            os.Stdout,
 			session:        getSessionMock(),
 			portParameters: PortParameters{PortNumber: "22", Type: "LocalPortForwarding"},
 		},

--- a/src/sessionmanagerplugin/session/portsession/portsession.go
+++ b/src/sessionmanagerplugin/session/portsession/portsession.go
@@ -15,6 +15,8 @@
 package portsession
 
 import (
+	"os"
+
 	"github.com/aws/session-manager-plugin/src/config"
 	"github.com/aws/session-manager-plugin/src/jsonutil"
 	"github.com/aws/session-manager-plugin/src/log"
@@ -70,12 +72,14 @@ func (s *PortSession) Initialize(log log.T, sessionVar *session.Session) {
 				sessionId:      s.SessionId,
 				portParameters: s.portParameters,
 				session:        s.Session,
+				out:            os.Stdout,
 			}
 		} else {
 			s.portSessionType = &BasicPortForwarding{
 				sessionId:      s.SessionId,
 				portParameters: s.portParameters,
 				session:        s.Session,
+				out:            os.Stdout,
 			}
 		}
 	} else {

--- a/src/sessionmanagerplugin/session/portsession/test_portsession.go
+++ b/src/sessionmanagerplugin/session/portsession/test_portsession.go
@@ -15,6 +15,8 @@
 package portsession
 
 import (
+	"os"
+
 	"github.com/aws/session-manager-plugin/src/communicator/mocks"
 	"github.com/aws/session-manager-plugin/src/datachannel"
 	"github.com/aws/session-manager-plugin/src/log"
@@ -41,11 +43,13 @@ func getSessionMock() session.Session {
 }
 
 func getSessionMockWithParams(properties interface{}, agentVersion string) session.Session {
-	datachannel := &datachannel.DataChannel{}
+	out := os.Stdout
+	datachannel := &datachannel.DataChannel{Out: out}
 	datachannel.SetAgentVersion(agentVersion)
 
 	var mockSession = session.Session{
 		DataChannel: datachannel,
+		Out:         out,
 	}
 
 	mockSession.DataChannel.Initialize(mockLog, "clientId", "sessionId", "targetId", false)

--- a/src/sessionmanagerplugin/session/session_test.go
+++ b/src/sessionmanagerplugin/session/session_test.go
@@ -104,7 +104,7 @@ func TestValidateInputAndStartSessionWithWrongEnvVariableName(t *testing.T) {
 }
 
 func TestExecute(t *testing.T) {
-	sessionMock := &Session{}
+	sessionMock := &Session{Out: os.Stdout}
 	sessionMock.DataChannel = mockDataChannel
 	SetupMockActions()
 	mockDataChannel.On("Open", mock.Anything).Return(nil)
@@ -128,7 +128,7 @@ func TestExecute(t *testing.T) {
 }
 
 func TestExecuteAndStreamMessageResendTimesOut(t *testing.T) {
-	sessionMock := &Session{}
+	sessionMock := &Session{Out: os.Stdout}
 	sessionMock.DataChannel = mockDataChannel
 	SetupMockActions()
 	mockDataChannel.On("Open", mock.Anything).Return(nil)

--- a/src/sessionmanagerplugin/session/sessionhandler.go
+++ b/src/sessionmanagerplugin/session/sessionhandler.go
@@ -129,7 +129,7 @@ func (s *Session) ResumeSessionHandler(log log.T) (err error) {
 		return
 	} else if s.TokenValue == "" {
 		log.Debugf("Session: %s timed out", s.SessionId)
-		fmt.Fprintf(os.Stdout, "Session: %s timed out.\n", s.SessionId)
+		fmt.Fprintf(s.Out, "Session: %s timed out.\n", s.SessionId)
 		os.Exit(0)
 	}
 	s.DataChannel.GetWsChannel().SetChannelToken(s.TokenValue)

--- a/src/sessionmanagerplugin/session/sessionhandler_test.go
+++ b/src/sessionmanagerplugin/session/sessionhandler_test.go
@@ -16,6 +16,7 @@ package session
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	wsChannelMock "github.com/aws/session-manager-plugin/src/communicator/mocks"
@@ -23,6 +24,7 @@ import (
 	"github.com/aws/session-manager-plugin/src/datachannel"
 	dataChannelMock "github.com/aws/session-manager-plugin/src/datachannel/mocks"
 	"github.com/aws/session-manager-plugin/src/message"
+	"github.com/aws/session-manager-plugin/src/sessionmanagerplugin/session/sessionutil"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stretchr/testify/assert"
@@ -38,7 +40,7 @@ func TestOpenDataChannel(t *testing.T) {
 	mockDataChannel = &dataChannelMock.IDataChannel{}
 	mockWsChannel = &wsChannelMock.IWebSocketChannel{}
 
-	sessionMock := &Session{}
+	sessionMock := &Session{Out: os.Stdout}
 	sessionMock.DataChannel = mockDataChannel
 	SetupMockActions()
 	mockDataChannel.On("Open", mock.Anything).Return(nil)
@@ -51,7 +53,7 @@ func TestOpenDataChannelWithError(t *testing.T) {
 	mockDataChannel = &dataChannelMock.IDataChannel{}
 	mockWsChannel = &wsChannelMock.IWebSocketChannel{}
 
-	sessionMock := &Session{}
+	sessionMock := &Session{Out: os.Stdout}
 	sessionMock.DataChannel = mockDataChannel
 	SetupMockActions()
 
@@ -69,10 +71,12 @@ func TestProcessFirstMessageOutputMessageFirst(t *testing.T) {
 		Payload:     []byte("testing"),
 	}
 
-	dataChannel := &datachannel.DataChannel{}
+	dataChannel := &datachannel.DataChannel{Out: os.Stdout}
 	dataChannel.Initialize(logger, clientId, sessionId, instanceId, false)
 	session := Session{
+		Out:         os.Stdout,
 		DataChannel: dataChannel,
+		DisplayMode: sessionutil.NewDisplayMode(logger, os.Stdout),
 	}
 
 	session.ProcessFirstMessage(logger, outputMessage)

--- a/src/sessionmanagerplugin/session/sessionutil/sessionutil.go
+++ b/src/sessionmanagerplugin/session/sessionutil/sessionutil.go
@@ -14,10 +14,14 @@
 // Package sessionutil provides utility for sessions.
 package sessionutil
 
-import "github.com/aws/session-manager-plugin/src/log"
+import (
+	"io"
 
-func NewDisplayMode(log log.T) DisplayMode {
-	displayMode := DisplayMode{}
+	"github.com/aws/session-manager-plugin/src/log"
+)
+
+func NewDisplayMode(log log.T, out io.Writer) DisplayMode {
+	displayMode := DisplayMode{out: out}
 	displayMode.InitDisplayMode(log)
 	return displayMode
 }

--- a/src/sessionmanagerplugin/session/sessionutil/sessionutil_unix.go
+++ b/src/sessionmanagerplugin/session/sessionutil/sessionutil_unix.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 
 	"github.com/aws/session-manager-plugin/src/log"
 	"github.com/aws/session-manager-plugin/src/message"
 )
 
 type DisplayMode struct {
+	out io.Writer
 }
 
 func (d *DisplayMode) InitDisplayMode(log log.T) {
@@ -35,8 +35,7 @@ func (d *DisplayMode) InitDisplayMode(log log.T) {
 
 // DisplayMessage function displays the output on the screen
 func (d *DisplayMode) DisplayMessage(log log.T, message message.ClientMessage) {
-	var out io.Writer = os.Stdout
-	fmt.Fprint(out, string(message.Payload))
+	fmt.Fprint(d.out, string(message.Payload))
 }
 
 // NewListener starts a new socket listener on the address.

--- a/src/sessionmanagerplugin/session/sessionutil/sessionutil_windows.go
+++ b/src/sessionmanagerplugin/session/sessionutil/sessionutil_windows.go
@@ -19,6 +19,7 @@ package sessionutil
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"syscall"
@@ -32,6 +33,7 @@ var EnvProgramFiles = os.Getenv("ProgramFiles")
 
 type DisplayMode struct {
 	handle windows.Handle
+	out    io.Writer
 }
 
 func (d *DisplayMode) InitDisplayMode(log log.T) {
@@ -71,7 +73,7 @@ func (d *DisplayMode) DisplayMessage(log log.T, message message.ClientMessage) {
 	// refer - https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-writefile
 	if err = windows.WriteFile(d.handle, message.Payload, done, nil); err != nil {
 		log.Errorf("error occurred while writing to file: %v", err)
-		fmt.Fprintf(os.Stdout, "\nError getting the output. %s\n", err.Error())
+		fmt.Fprintf(d.out, "\nError getting the output. %s\n", err.Error())
 		os.Exit(0)
 	}
 }

--- a/src/sessionmanagerplugin/session/shellsession/shellsession_test.go
+++ b/src/sessionmanagerplugin/session/shellsession/shellsession_test.go
@@ -52,7 +52,7 @@ func TestName(t *testing.T) {
 }
 
 func TestInitialize(t *testing.T) {
-	session := &session.Session{}
+	session := &session.Session{Out: os.Stdout}
 	shellSession := ShellSession{}
 	session.DataChannel = mockDataChannel
 	mockDataChannel.On("RegisterOutputStreamHandler", mock.Anything, true).Times(1)
@@ -63,7 +63,7 @@ func TestInitialize(t *testing.T) {
 }
 
 func TestHandleControlSignals(t *testing.T) {
-	session := session.Session{}
+	session := session.Session{Out: os.Stdout}
 	session.DataChannel = mockDataChannel
 	shellSession := ShellSession{}
 	shellSession.Session = session
@@ -154,7 +154,7 @@ func TestTerminalResizeWhenSessionSizeDataIsNotEqualToActualSize(t *testing.T) {
 
 func TestProcessStreamMessagePayload(t *testing.T) {
 	shellSession := ShellSession{}
-	shellSession.DisplayMode = sessionutil.NewDisplayMode(logger)
+	shellSession.DisplayMode = sessionutil.NewDisplayMode(logger, os.Stdout)
 
 	msg := message.ClientMessage{
 		Payload: []byte("Hello Agent\n"),
@@ -165,7 +165,7 @@ func TestProcessStreamMessagePayload(t *testing.T) {
 }
 
 func getDataChannel() *datachannel.DataChannel {
-	dataChannel := &datachannel.DataChannel{}
+	dataChannel := &datachannel.DataChannel{Out: os.Stdout}
 	dataChannel.Initialize(logger, clientId, sessionId, instanceId, false)
 	dataChannel.SetWsChannel(mockWsChannel)
 	return dataChannel

--- a/src/ssmclicommands/inputhandler.go
+++ b/src/ssmclicommands/inputhandler.go
@@ -106,7 +106,7 @@ func ValidateInput(args []string, out io.Writer) {
 		if utils.IsHelp(subcommand, parameters) {
 			fmt.Fprintln(out, cmd.Help())
 		} else {
-			cmdErr, result := cmd.Execute(parameters)
+			cmdErr, result := cmd.Execute(out, parameters)
 			if cmdErr != nil {
 				utils.DisplayCommandUsage(out)
 				fmt.Fprint(out, cmdErr.Error())

--- a/src/ssmclicommands/startsession.go
+++ b/src/ssmclicommands/startsession.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"io"
 	"strings"
 
 	sdkSession "github.com/aws/aws-sdk-go/aws/session"
@@ -88,7 +89,7 @@ type StartSessionCommand struct {
 	sdk      *ssm.SSM
 }
 
-//getSSMClient generate ssm client by configuration
+// getSSMClient generate ssm client by configuration
 var getSSMClient = func(log log.T, region string, profile string, endpoint string) (*ssm.SSM, error) {
 	sdkutil.SetRegionAndProfile(region, profile)
 
@@ -101,7 +102,7 @@ var getSSMClient = func(log log.T, region string, profile string, endpoint strin
 	return ssm.New(sdkSession), nil
 }
 
-//executeSession to open datachannel
+// executeSession to open datachannel
 var executeSession = func(log log.T, session *session.Session) (err error) {
 	return session.Execute(log)
 }
@@ -141,8 +142,8 @@ func (c *StartSessionCommand) Help() string {
 	return c.helpText
 }
 
-//validates and execute start-session command
-func (s *StartSessionCommand) Execute(parameters map[string][]string) (error, string) {
+// validates and execute start-session command
+func (s *StartSessionCommand) Execute(out io.Writer, parameters map[string][]string) (error, string) {
 	var (
 		err        error
 		region     string
@@ -191,7 +192,8 @@ func (s *StartSessionCommand) Execute(parameters map[string][]string) (error, st
 		Endpoint:    endpoint,
 		ClientId:    clientId,
 		TargetId:    instanceId,
-		DataChannel: &datachannel.DataChannel{},
+		DataChannel: &datachannel.DataChannel{Out: out},
+		Out:         out,
 	}
 
 	if err = executeSession(log, &session); err != nil {
@@ -202,7 +204,7 @@ func (s *StartSessionCommand) Execute(parameters map[string][]string) (error, st
 	return err, "StartSession executed successfully"
 }
 
-//func to validate start-session input
+// func to validate start-session input
 func (StartSessionCommand) validateStartSessionInput(parameters map[string][]string) []string {
 	validation := make([]string, 0)
 

--- a/src/ssmclicommands/startsession_test.go
+++ b/src/ssmclicommands/startsession_test.go
@@ -16,6 +16,7 @@ package ssmclicommands
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -75,7 +76,7 @@ func TestStartSessionCommand_ExecuteSuccess(t *testing.T) {
 		return startSessionOutput, nil
 	}
 
-	err, msg := command.Execute(parameter)
+	err, msg := command.Execute(os.Stdout, parameter)
 	assert.Nil(t, err)
 	assert.Equal(t, msg, "StartSession executed successfully")
 }
@@ -91,7 +92,7 @@ func TestStartSessionCommand_ExecuteGetSSMClientFailure(t *testing.T) {
 		return nil, fmt.Errorf("Get SSMClient Failure")
 	}
 
-	err, msg := command.Execute(parameter)
+	err, msg := command.Execute(os.Stdout, parameter)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "Get SSMClient Failure")
 	assert.Equal(t, msg, "StartSession failed")
@@ -115,7 +116,7 @@ func TestStartSessionCommand_ExecuteSessionFailure(t *testing.T) {
 		return startSessionOutput, nil
 	}
 
-	err, msg := command.Execute(parameter)
+	err, msg := command.Execute(os.Stdout, parameter)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "Execute Session Failure")
 	assert.Equal(t, msg, "StartSession failed")

--- a/src/ssmclicommands/utils/util.go
+++ b/src/ssmclicommands/utils/util.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -30,7 +31,7 @@ var SsmCliCommands map[string]SsmCliCommand
 
 // CliCommand defines the interface for all commands the cli can execute
 type SsmCliCommand interface {
-	Execute(parameters map[string][]string) (error, string)
+	Execute(out io.Writer, parameters map[string][]string) (error, string)
 	Help() string
 	Name() string
 }


### PR DESCRIPTION
## Details 

Closes #85

Introduces an env-var config option `AWS_SSM_QUIET` to disable writing information messages to stdout; instead sending them to stderr. 

Considerations: I kinda just went with stderr; but we could also just send them to `io.Discard` instead if that makes more sense to others.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### Rationale

There's suggestions to use `grep` or `head`/`tail` to filter these out; however this doesn't work in many cases for quite a few reasons:

- Filtering the output means we may not see other messages with the same text that isn't coming from SSM. Eg `grep -v SessionId` will filter out lines with `SessionId` coming from the remote host.
- These tools only work on ASCII and passing binary data through them may not work as expected. 
- It assumes the output of these logs never change, making it very fragile.
- Tools like grep, head and tail are all line buffered, so anything interactive that also needs to filter the output will be a degraded user-experience due to the buffering. Also buffering can break many terminal features entirely.
- It can be difficult to actually remove the "correct" output. If I'm trying to `cat` a binary file from the remote host and store that output locally; I have to filter the `Starting session` output, the `Exiting session` output, and I need to ensure I remove the empty lines before/after the log messages too. Doing it correctly is quite difficult. 

The change is opt-in, meaning it won't effect anyone who doesn't configure `AWS_SSM_QUIET`, and in general; the output is still produced, but it goes to stderr which users will still see in their terminal, the only impact is if your passing the output of SSM to another program with the env-var set.