### PR TITLE
Add shebang lines to all debian packaging scripts

### DIFF
--- a/packaging/ubuntu_plugin/postinst
+++ b/packaging/ubuntu_plugin/postinst
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 echo "Creating symbolic link for session-manager-plugin"
 if [ -f /usr/local/bin/session-manager-plugin ]
 then

--- a/packaging/ubuntu_plugin/postrm
+++ b/packaging/ubuntu_plugin/postrm
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 if [ -f /usr/local/bin/session-manager-plugin ]
 then
     rm /usr/local/bin/session-manager-plugin

--- a/packaging/ubuntu_plugin/preinst
+++ b/packaging/ubuntu_plugin/preinst
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 echo "Preparing for install"

--- a/packaging/ubuntu_plugin/prerm
+++ b/packaging/ubuntu_plugin/prerm
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 echo "Start removing session-manager-plugin"


### PR DESCRIPTION
Pretty much the same as #25

Add a shbang using `/bin/sh` to all the debian scripts. Installing the session-manager-plugin under the docker-buildkit QEMU build emulation fails without this since it tries to interpret the scripts as binaries, which they are not. Adding the shbang line makes the interpreter correctly understand these are shell scripts and run them under the shell, rather than as a binary.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
