### PR TITLE
Add Escape Sequences to Shell Sessions

### DIFF
--- a/src/sessionmanagerplugin/session/shellsession/shellsession.go
+++ b/src/sessionmanagerplugin/session/shellsession/shellsession.go
@@ -40,6 +40,7 @@ type ShellSession struct {
 	// SizeData is used to store size data at session level to compare with new size.
 	SizeData          message.SizeData
 	originalSttyState bytes.Buffer
+	escapeTracking    ShellEscapeSequenceTracking
 }
 
 var GetTerminalSizeCall = func(fd int) (width int, height int, err error) {
@@ -62,6 +63,11 @@ func (s *ShellSession) Initialize(log log.T, sessionVar *session.Session) {
 		func(input []byte) {
 			s.DataChannel.OutputMessageHandler(log, s.Stop, s.SessionId, input)
 		})
+	s.escapeTracking = ShellEscapeSequenceTracking{
+		enabled: true,
+		newline: false,
+		escaped: false,
+	}
 }
 
 // StartSession takes input and write it to data channel
@@ -137,4 +143,36 @@ func (s *ShellSession) handleTerminalResize(log log.T) {
 func (s ShellSession) ProcessStreamMessagePayload(log log.T, outputMessage message.ClientMessage) (isHandlerReady bool, err error) {
 	s.DisplayMode.DisplayMessage(log, outputMessage)
 	return true, nil
+}
+
+// Shell Session Escape Sequence Tracking Flags
+type ShellEscapeSequenceTracking struct {
+	enabled bool // whether the shell session should check for escape sequences
+	newline bool // whether the last character was a newline (the first half of the trigger)
+	escaped bool // whether the shell session is escaped (the second half of the trigger)
+}
+
+// Reset Escape Sequence due to finishing an escape sequence, or invalid escape sequence.
+func (s *ShellEscapeSequenceTracking) Reset() {
+	s.escaped = false
+	s.newline = false
+}
+
+// Disable checking for Escape Sequences for the rest of the connected Session.
+func (s *ShellEscapeSequenceTracking) Disable() {
+	s.enabled = false
+}
+
+// First half of trigger (newline) detected
+func (s *ShellEscapeSequenceTracking) HalfTrigger() {
+	s.newline = true
+}
+
+// Second half of trigger (~) detected
+func (s *ShellEscapeSequenceTracking) Trigger() {
+	if s.newline {
+		s.escaped = true
+	} else {
+		panic("Unexpected trigger, when prior newline missing")
+	}
 }

--- a/src/sessionmanagerplugin/session/shellsession/shellsession_unix.go
+++ b/src/sessionmanagerplugin/session/shellsession/shellsession_unix.go
@@ -75,6 +75,13 @@ func (s *ShellSession) handleKeyboardInput(log log.T) (err error) {
 			break
 		}
 
+		if skip, err := s.handleEscapeSequence(log, stdinBytes, stdinBytesLen); err != nil {
+			log.Errorf("Escape sequence failure: %v", err)
+			s.Stop()
+		} else if skip {
+			continue
+		}
+
 		if err = s.Session.DataChannel.SendInputDataMessage(log, message.Output, stdinBytes[:stdinBytesLen]); err != nil {
 			log.Errorf("Failed to send UTF8 char: %v", err)
 			break

--- a/src/sessionmanagerplugin/session/shellsession/shellsession_windows.go
+++ b/src/sessionmanagerplugin/session/shellsession/shellsession_windows.go
@@ -77,6 +77,12 @@ func (s *ShellSession) handleKeyboardInput(log log.T) (err error) {
 		}
 		if character != 0 {
 			charBytes := []byte(string(character))
+			if skip, err := s.handleEscapeSequence(log, charBytes, len(charBytes)); err != nil {
+				log.Errorf("Escape sequence failure: %v", err)
+				s.Stop()
+			} else if skip {
+				continue
+			}
 			if err = s.Session.DataChannel.SendInputDataMessage(log, message.Output, charBytes); err != nil {
 				log.Errorf("Failed to send UTF8 char: %v", err)
 				break
@@ -85,6 +91,12 @@ func (s *ShellSession) handleKeyboardInput(log log.T) (err error) {
 			keyBytes := []byte(string(key))
 			if byteValue, ok := specialKeysInputMap[key]; ok {
 				keyBytes = byteValue
+			}
+			if skip, err := s.handleEscapeSequence(log, keyBytes, len(keyBytes)); err != nil {
+				log.Errorf("Escape sequence failure: %v", err)
+				s.Stop()
+			} else if skip {
+				continue
 			}
 			if err = s.Session.DataChannel.SendInputDataMessage(log, message.Output, keyBytes); err != nil {
 				log.Errorf("Failed to send UTF8 char: %v", err)


### PR DESCRIPTION
*Issue*
- #6

*Description of changes:*
Add a SSH-like escape sequence to shell sessions.

As a start, the only functionality is terminating the session.
This allows an operator to terminate their session if the remote target becomes unresponsive.

> [!WARNING]
Please note that session termination does not current work for AWS SSO / Identity Center authentication credentials.
This is due to a bug in session-manager-plugin, which interferes with refreshing SSO tokens.
(I'll raise a separate PR for that issue).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
