### PR TITLE
fix: Prevent global config of API Endpoint

### DIFF
--- a/src/sdkutil/awsconfig.go
+++ b/src/sdkutil/awsconfig.go
@@ -26,14 +26,13 @@ import (
 var defaultRegion string
 var defaultProfile string
 
-// GetNewSessionWithEndpoint creates aws sdk session with given profile, region and endpoint
-func GetNewSessionWithEndpoint(endpoint string) (sess *session.Session, err error) {
+// GetDefaultSession creates aws sdk session with given profile and region
+func GetDefaultSession() (sess *session.Session, err error) {
 	if sess, err = session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			Retryer:    newRetryer(),
 			SleepDelay: sleepDelay,
 			Region:     aws.String(defaultRegion),
-			Endpoint:   aws.String(endpoint),
 		},
 		SharedConfigState: session.SharedConfigEnable,
 		Profile:           defaultProfile,
@@ -41,11 +40,6 @@ func GetNewSessionWithEndpoint(endpoint string) (sess *session.Session, err erro
 		return nil, fmt.Errorf("Error creating new aws sdk session %s", err)
 	}
 	return sess, nil
-}
-
-// GetDefaultSession creates aws sdk session with given profile and region
-func GetDefaultSession() (sess *session.Session, err error) {
-	return GetNewSessionWithEndpoint("")
 }
 
 // Sets the region and profile for default aws sessions

--- a/src/ssmclicommands/startsession.go
+++ b/src/ssmclicommands/startsession.go
@@ -21,7 +21,7 @@ import (
 	"html/template"
 	"strings"
 
-	sdkSession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/session-manager-plugin/src/datachannel"
 	"github.com/aws/session-manager-plugin/src/jsonutil"
@@ -92,13 +92,11 @@ type StartSessionCommand struct {
 var getSSMClient = func(log log.T, region string, profile string, endpoint string) (*ssm.SSM, error) {
 	sdkutil.SetRegionAndProfile(region, profile)
 
-	var sdkSession *sdkSession.Session
-	sdkSession, err := sdkutil.GetNewSessionWithEndpoint(endpoint)
-	if err != nil {
-		log.Errorf("Get session with endpoint Failed: %v", err)
+	if sdkSession, err := sdkutil.GetDefaultSession(); err != nil {
 		return nil, err
+	} else {
+		return ssm.New(sdkSession, aws.NewConfig().WithEndpoint(endpoint)), nil
 	}
-	return ssm.New(sdkSession), nil
 }
 
 // executeSession to open datachannel


### PR DESCRIPTION
*Issues*
- Related to pull request #96

*Description of changes:*
There is a bug where the AWS SDK session is configured to use a specific endpoint.
This commit moves the endpoint configuration from the SDK Session to specific SDK Clients (SSM).

The SSM endpoint is passed in to the session-manager-plugin from the AWS CLI, and I believe the intention is to ensure any Region overrides from the AWS CLI are respected by the session-manager-plugin.

A problem occurs when the AWS credentials are sourced from AWS SSO / Identity Center.
When the SDK Session is configured with an endpoint, this overrides all Service Endpoints, including SDK internal SSO credential providers. When the current SSO credentials need to be refreshed, the refresh request is sent to `https://ssm.[aws-region].amazonaws.com/token`. The SSM API does not know about the /token endpoint, or CreateToken operation, and returns an UnknownOperation error.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
