### PR TITLE
Return based exiting

### DIFF
--- a/src/datachannel/streaming.go
+++ b/src/datachannel/streaming.go
@@ -62,6 +62,8 @@ type IDataChannel interface {
 	RegisterOutputStreamHandler(handler OutputStreamDataMessageHandler, isSessionSpecificHandler bool)
 	DeregisterOutputStreamHandler(handler OutputStreamDataMessageHandler)
 	IsSessionTypeSet() chan bool
+	EndSession() error
+	IsSessionEnded() bool
 	IsStreamMessageResendTimeout() chan bool
 	GetSessionType() string
 	SetSessionType(sessionType string)
@@ -105,6 +107,8 @@ type DataChannel struct {
 	sessionType       string
 	isSessionTypeSet  chan bool
 	sessionProperties interface{}
+
+	isSessionEnded bool
 
 	// Used to detect if resending a streaming message reaches timeout
 	isStreamMessageResendTimeout chan bool
@@ -187,6 +191,7 @@ func (dataChannel *DataChannel) Initialize(log log.T, clientId string, sessionId
 	dataChannel.wsChannel = &communicator.WebSocketChannel{}
 	dataChannel.encryptionEnabled = false
 	dataChannel.isSessionTypeSet = make(chan bool, 1)
+	dataChannel.isSessionEnded = false
 	dataChannel.isStreamMessageResendTimeout = make(chan bool, 1)
 	dataChannel.sessionType = ""
 	dataChannel.IsAwsCliUpgradeNeeded = isAwsCliUpgradeNeeded
@@ -199,7 +204,7 @@ func (dataChannel *DataChannel) SetWebsocket(log log.T, channelUrl string, chann
 
 // FinalizeHandshake sends the token for service to acknowledge the connection.
 func (dataChannel *DataChannel) FinalizeDataChannelHandshake(log log.T, tokenValue string) (err error) {
-	uuid.SwitchFormat(uuid.CleanHyphen)
+	uuid.SwitchFormat(uuid.FormatCanonical)
 	uid := uuid.NewV4().String()
 
 	log.Infof("Sending token through data channel %s to acknowledge connection", dataChannel.wsChannel.GetStreamUrl())
@@ -772,7 +777,7 @@ func (dataChannel *DataChannel) HandleAcknowledgeMessage(
 }
 
 // handleChannelClosedMessage exits the shell
-func (dataChannel DataChannel) HandleChannelClosedMessage(log log.T, stopHandler Stop, sessionId string, outputMessage message.ClientMessage) {
+func (dataChannel *DataChannel) HandleChannelClosedMessage(log log.T, stopHandler Stop, sessionId string, outputMessage message.ClientMessage) {
 	var (
 		channelClosedMessage message.ChannelClosed
 		err                  error
@@ -787,6 +792,8 @@ func (dataChannel DataChannel) HandleChannelClosedMessage(log log.T, stopHandler
 	} else {
 		fmt.Fprintf(os.Stdout, "\n\nSessionId: %s : %s\n\n", sessionId, channelClosedMessage.Output)
 	}
+	dataChannel.EndSession()
+	dataChannel.Close(log)
 
 	stopHandler()
 }
@@ -849,7 +856,7 @@ func (dataChannel *DataChannel) CalculateRetransmissionTimeout(log log.T, stream
 func (dataChannel *DataChannel) ProcessKMSEncryptionHandshakeAction(log log.T, actionParams json.RawMessage) (err error) {
 
 	if dataChannel.IsAwsCliUpgradeNeeded {
-		return errors.New("Installed version of CLI does not support Session Manager encryption feature. Please upgrade to the latest version of your CLI (e.g., AWS CLI).")
+		return errors.New("installed version of CLI does not support Session Manager encryption feature. Please upgrade to the latest version of your CLI (e.g., AWS CLI)")
 	}
 	kmsEncRequest := message.KMSEncryptionRequest{}
 	json.Unmarshal(actionParams, &kmsEncRequest)
@@ -881,13 +888,24 @@ func (dataChannel *DataChannel) ProcessSessionTypeHandshakeAction(actionParams j
 		dataChannel.sessionProperties = sessTypeReq.Properties
 		return nil
 	default:
-		return errors.New(fmt.Sprintf("Unknown session type %s", sessTypeReq.SessionType))
+		return fmt.Errorf("Unknown session type %s", sessTypeReq.SessionType)
 	}
 }
 
 // IsSessionTypeSet check has data channel sessionType been set
 func (dataChannel *DataChannel) IsSessionTypeSet() chan bool {
 	return dataChannel.isSessionTypeSet
+}
+
+// IsSessionEnded check if session has ended
+func (dataChannel *DataChannel) IsSessionEnded() bool {
+	return dataChannel.isSessionEnded
+}
+
+// IsSessionEnded check if session has ended
+func (dataChannel *DataChannel) EndSession() error {
+	dataChannel.isSessionEnded = true
+	return nil
 }
 
 // IsStreamMessageResendTimeout checks if resending a streaming message reaches timeout

--- a/src/message/messageparser.go
+++ b/src/message/messageparser.go
@@ -167,31 +167,31 @@ func getUuid(log log.T, byteArray []byte, offset int) (result uuid.UUID, err err
 	byteArrayLength := len(byteArray)
 	if offset > byteArrayLength-1 || offset+16-1 > byteArrayLength-1 || offset < 0 {
 		log.Error("getUuid failed: Offset is invalid.")
-		return nil, errors.New("Offset is outside the byte array.")
+		return uuid.Nil.UUID(), errors.New("Offset is outside the byte array.")
 	}
 
 	leastSignificantLong, err := getLong(log, byteArray, offset)
 	if err != nil {
 		log.Error("getUuid failed: failed to get uuid LSBs Long value.")
-		return nil, errors.New("Failed to get uuid LSBs long value.")
+		return uuid.Nil.UUID(), errors.New("Failed to get uuid LSBs long value.")
 	}
 
 	leastSignificantBytes, err := longToBytes(log, leastSignificantLong)
 	if err != nil {
 		log.Error("getUuid failed: failed to get uuid LSBs bytes value.")
-		return nil, errors.New("Failed to get uuid LSBs bytes value.")
+		return uuid.Nil.UUID(), errors.New("Failed to get uuid LSBs bytes value.")
 	}
 
 	mostSignificantLong, err := getLong(log, byteArray, offset+8)
 	if err != nil {
 		log.Error("getUuid failed: failed to get uuid MSBs Long value.")
-		return nil, errors.New("Failed to get uuid MSBs long value.")
+		return uuid.Nil.UUID(), errors.New("Failed to get uuid MSBs long value.")
 	}
 
 	mostSignificantBytes, err := longToBytes(log, mostSignificantLong)
 	if err != nil {
 		log.Error("getUuid failed: failed to get uuid MSBs bytes value.")
-		return nil, errors.New("Failed to get uuid MSBs bytes value.")
+		return uuid.Nil.UUID(), errors.New("Failed to get uuid MSBs bytes value.")
 	}
 
 	uuidBytes := append(mostSignificantBytes, leastSignificantBytes...)
@@ -414,7 +414,7 @@ func putBytes(log log.T, byteArray []byte, offsetStart int, offsetEnd int, input
 
 // putUuid puts the 128 bit uuid to an array of bytes starting from the offset.
 func putUuid(log log.T, byteArray []byte, offset int, input uuid.UUID) (err error) {
-	if input == nil {
+	if uuid.IsNil(input) {
 		log.Error("putUuid failed: input is null.")
 		return errors.New("putUuid failed: input is null.")
 	}
@@ -494,7 +494,7 @@ func SerializeClientMessageWithAcknowledgeContent(log log.T, acknowledgeContent 
 		return
 	}
 
-	uuid.SwitchFormat(uuid.CleanHyphen)
+	uuid.SwitchFormat(uuid.FormatCanonical)
 	messageId := uuid.NewV4()
 	clientMessage := ClientMessage{
 		MessageType:    AcknowledgeMessage,

--- a/src/sessionmanagerplugin/session/sessionhandler.go
+++ b/src/sessionmanagerplugin/session/sessionhandler.go
@@ -87,9 +87,7 @@ func (s *Session) ProcessFirstMessage(log log.T, outputMessage message.ClientMes
 }
 
 // Stop will end the session
-func (s *Session) Stop() {
-	os.Exit(0)
-}
+func (s *Session) Stop() {}
 
 // GetResumeSessionParams calls ResumeSession API and gets tokenvalue for reconnecting
 func (s *Session) GetResumeSessionParams(log log.T) (string, error) {
@@ -130,7 +128,7 @@ func (s *Session) ResumeSessionHandler(log log.T) (err error) {
 	} else if s.TokenValue == "" {
 		log.Debugf("Session: %s timed out", s.SessionId)
 		fmt.Fprintf(os.Stdout, "Session: %s timed out.\n", s.SessionId)
-		os.Exit(0)
+		return
 	}
 	s.DataChannel.GetWsChannel().SetChannelToken(s.TokenValue)
 	err = s.DataChannel.Reconnect(log)

--- a/src/sessionmanagerplugin/session/sessionutil/sessionutil_windows.go
+++ b/src/sessionmanagerplugin/session/sessionutil/sessionutil_windows.go
@@ -72,7 +72,7 @@ func (d *DisplayMode) DisplayMessage(log log.T, message message.ClientMessage) {
 	if err = windows.WriteFile(d.handle, message.Payload, done, nil); err != nil {
 		log.Errorf("error occurred while writing to file: %v", err)
 		fmt.Fprintf(os.Stdout, "\nError getting the output. %s\n", err.Error())
-		os.Exit(0)
+		return
 	}
 }
 


### PR DESCRIPTION
changes:

- Fixes to UUID calls to work with newer versions of golang
- Flag and functions added to datachannel that define whether a session has ended and set the value of the session end flag. this is to support cleaner exiting of code.
- All os.Exit calls have been replaced with return. This is because when using this module as a library in other codebases, it is desirable to execute other code after this module has completed. os.Exit simultaneously kills all goroutines and the main process, making it impossible to execute code after the fact. This creates some issues addressed in other changes.
- The main function handling keyboard input for shell sessions has been modified so that the blocking loop waiting on input is now in its own goroutine. This allows the main routine to check whether the session has ended and will no longer get stuck in an infinite blocking wait. The select block is used to check whether the session has ended and returns if it has.
- Control signals on port sessions are now being handled and trigger the session end. This required modifying the local listeners on the mux clients so that they could be accessed by other functions. This allows them to be cleanly closed when sessions have ended.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
