### PR TITLE
Fix checkstyle linting issues where printf is called without arguments

### DIFF
--- a/src/log/test_log.go
+++ b/src/log/test_log.go
@@ -96,7 +96,7 @@ func (_m *Mock) Infof(format string, params ...interface{}) {
 func (_m *Mock) Warnf(format string, params ...interface{}) error {
 	fmt.Print(_m.context)
 	msg := fmt.Sprintf("Warnf: "+format, params...)
-	fmt.Printf(msg)
+	fmt.Print(msg)
 	fmt.Println()
 	_m.Called(format, params)
 	return errors.New(msg)
@@ -106,7 +106,7 @@ func (_m *Mock) Warnf(format string, params ...interface{}) error {
 func (_m *Mock) Errorf(format string, params ...interface{}) error {
 	fmt.Print(_m.context)
 	msg := fmt.Sprintf("Errorf: "+format, params...)
-	fmt.Printf(msg)
+	fmt.Print(msg)
 	fmt.Println()
 	_m.Called(format, params)
 	return errors.New(msg)
@@ -116,7 +116,7 @@ func (_m *Mock) Errorf(format string, params ...interface{}) error {
 func (_m *Mock) Criticalf(format string, params ...interface{}) error {
 	fmt.Print(_m.context)
 	msg := fmt.Sprintf("Criticalf: "+format, params...)
-	fmt.Printf(msg)
+	fmt.Print(msg)
 	fmt.Println()
 	_m.Called(format, params)
 	return errors.New(msg)
@@ -150,7 +150,7 @@ func (_m *Mock) Info(v ...interface{}) {
 func (_m *Mock) Warn(v ...interface{}) error {
 	fmt.Print(_m.context)
 	msg := fmt.Sprint("Warn: ") + fmt.Sprint(v...)
-	fmt.Printf(msg)
+	fmt.Print(msg)
 	fmt.Println()
 	_m.Called(v)
 	return errors.New(msg)
@@ -160,7 +160,7 @@ func (_m *Mock) Warn(v ...interface{}) error {
 func (_m *Mock) Error(v ...interface{}) error {
 	fmt.Print(_m.context)
 	msg := fmt.Sprint("Error: ") + fmt.Sprint(v...)
-	fmt.Printf(msg)
+	fmt.Print(msg)
 	fmt.Println()
 	_m.Called(v)
 	return errors.New(msg)

--- a/src/sessionmanagerplugin/session/portsession/muxportforwarding.go
+++ b/src/sessionmanagerplugin/session/portsession/muxportforwarding.go
@@ -92,7 +92,6 @@ func (p *MuxPortForwarding) Stop() {
 
 // InitializeStreams initializes i/o streams
 func (p *MuxPortForwarding) InitializeStreams(log log.T, agentVersion string) (err error) {
-
 	p.handleControlSignals(log)
 	p.socketFile = getUnixSocketPath(p.sessionId, os.TempDir(), "session_manager_plugin_mux.sock")
 
@@ -144,7 +143,6 @@ func (p *MuxPortForwarding) cleanUp() {
 
 // initialize opens a network connection that acts as smux client
 func (p *MuxPortForwarding) initialize(log log.T, agentVersion string) (err error) {
-
 	// open a network listener
 	var listener net.Listener
 	if listener, err = sessionutil.NewListener(log, p.socketFile); err != nil {
@@ -252,7 +250,7 @@ func (p *MuxPortForwarding) handleClientConnections(log log.T, ctx context.Conte
 	defer listener.Close()
 
 	log.Infof(displayMsg)
-	fmt.Printf(displayMsg)
+	fmt.Print(displayMsg)
 
 	log.Infof("Waiting for connections...\n")
 	fmt.Printf("\nWaiting for connections...\n")


### PR DESCRIPTION
*Description of changes:*
Go 1.24 introduces a new linting check (see related go issue: https://github.com/golang/go/issues/60529). This reports cases where a call to `fmt.printf` is made with a variable format and no arguments. In all the reported cases, the message was being generated prior to the printf call, so my assumption was that it could use `fmt.print` instead. I know you do not currently support 1.24, but we would like to use the latest version of go with this tool and the `make release` command fails due to this checkstyle issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
