### PR TITLE
Fixes Chinese and Japanese character display corruption on Windows platform

### DIFF
--- a/src/sessionmanagerplugin/session/sessionutil/sessionutil_windows.go
+++ b/src/sessionmanagerplugin/session/sessionutil/sessionutil_windows.go
@@ -62,18 +62,7 @@ func (d *DisplayMode) InitDisplayMode(log log.T) {
 
 // DisplayMessage function displays the output on the screen
 func (d *DisplayMode) DisplayMessage(log log.T, message message.ClientMessage) {
-	var (
-		done *uint32
-		err  error
-	)
-
-	// writes data to the specified file or input/output (I/O) device
-	// refer - https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-writefile
-	if err = windows.WriteFile(d.handle, message.Payload, done, nil); err != nil {
-		log.Errorf("error occurred while writing to file: %v", err)
-		fmt.Fprintf(os.Stdout, "\nError getting the output. %s\n", err.Error())
-		os.Exit(0)
-	}
+	fmt.Fprint(os.Stdout, string(message.Payload))
 }
 
 // NewListener starts a new socket listener on the address.


### PR DESCRIPTION
Issue #13

When typing Chinese or Japanese characters in Session Manager on Windows, the characters display as garbled text (e.g., "中文" appears as "荳ｭ譁"). This issue doesn't occur on Ubuntu/Linux platforms.

**Description of changes**:

This PR fixes UTF-8 encoding issues that cause Chinese and Japanese characters to display as garbled text on Windows platform.

- Replace windows.WriteFile with fmt.Fprint for consistent UTF-8 output display
- Ensures Windows version handles UTF-8 the same way as Unix version

**Problem**:

- Windows version used windows.WriteFile API for output, which doesn't handle UTF-8 properly
- Chinese/Japanese input displayed as corrupted characters (e.g., "中文" showed as "荳ｭ譁")

**Solution**:

- Output fix: Replace windows.WriteFile with fmt.Fprint in sessionutil_windows.go to match Unix behavior and ensure proper UTF-8 handling

**Testing**:

- Verified Chinese and Japanese characters now display correctly on Windows
- No impact on Unix/Linux platforms (they continue to work as before)
- Maintains backward compatibility for ASCII characters

This change aligns Windows UTF-8 handling with the Unix implementation, ensuring consistent behavior across platforms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.