### PR TITLE
[github-issue/118] bugfix: files being created with root ownership;

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ FROM public.ecr.aws/docker/library/golang:1.23
 RUN apt -y update && apt -y upgrade && apt -y install rpm tar gzip wget zip && apt clean all
 
 RUN mkdir /session-manager-plugin
-WORKDIR /session-manager-plugin
+WORKDIR   /session-manager-plugin
+ENV  HOME=/session-manager-plugin

--- a/README.md
+++ b/README.md
@@ -40,11 +40,17 @@ To build the Session Manager plugin in a `Docker` container, complete the follow
 
 2. Build the `docker` image
 ```
-docker build -t session-manager-plugin-image .
+docker build --tag session-manager-plugin-image .
 ```
 3. Build the plugin
 ```
-docker run -it --rm --name session-manager-plugin -v `pwd`:/session-manager-plugin session-manager-plugin-image make release
+docker run --interactive --rm --tty \
+   --name session-manager-plugin \
+   --security-opt label=disable \
+   --user $(id --user):$(id --group) \
+   --volume ${PWD}:/session-manager-plugin \
+   session-manager-plugin-image \
+   make release
 ```
 
 ### Working with Linux


### PR DESCRIPTION
Some additional options were added to docker-run, to address a handful of permissions issues.

SELinux labels needed to be disabled, because the ones it inherited from the home directory didn't make any sense for use inside of a container; and with them enabled, a permission denied error resulted when attempting to read the makefile (which was a non-starter, as you can imagine).

Additionally, running the container as the user that started it is intended to ensure the files are owned by that user when they are created similarly for the effective group.  This way, after the build is complete and the container has exited, the files that are the result of the build output aren't owned by root.

Besides telling docker-run to use a non-root user, it was also necessary add an option to the Dockerfile, to tell it the proper home directory to use (same as WORKDIR).

And the final change comes down to a matter of taste and style, so YMMV: short-form flags to docker-run were changed to their equivalent long-form. This was done because I feel it is better form to do so in the context of documentation (i.e., a README.md in this case).  And short-form flags would not really save the user much typing, because they are most likely using the copy-to-clipboard widget anyway.

This is intended to address the following issue:

https://github.com/aws/session-manager-plugin/issues/118

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
