### PR TITLE
Disable DSUSP (Ctrl+Y) on macOS/BSD to prevent session termination (#29)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,7 @@ Latest
 ================
 - Add SSH-style escape sequences to shell sessions (~. to terminate, ~? for help)
 - Fix port forwarding sessions silently dying after WebSocket reconnection
+- Fix shell sessions terminating on macOS/BSD when Ctrl+Y is pressed by disabling the DSUSP terminal control character
 
 1.2.814.0
 ================

--- a/src/sessionmanagerplugin/session/shellsession/shellsession_bsd.go
+++ b/src/sessionmanagerplugin/session/shellsession/shellsession_bsd.go
@@ -1,0 +1,32 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//go:build darwin || freebsd || netbsd || openbsd
+// +build darwin freebsd netbsd openbsd
+
+// Package shellsession starts shell session.
+package shellsession
+
+import "bytes"
+
+// disableDelayedSuspend disables the DSUSP terminal special character (Ctrl+Y by
+// default) on BSD-derived systems, including macOS.
+//
+// In cbreak mode the terminal driver still acts on DSUSP, so pressing Ctrl+Y
+// triggers a delayed suspend that causes the Stdin read to fail with
+// "read /dev/stdin: resource temporarily unavailable" and the session to
+// terminate. Linux does not implement DSUSP, so this is a no-op there.
+// See https://github.com/aws/session-manager-plugin/issues/29.
+func (s *ShellSession) disableDelayedSuspend() {
+	setState(bytes.NewBufferString("dsusp undef"))
+}

--- a/src/sessionmanagerplugin/session/shellsession/shellsession_linux.go
+++ b/src/sessionmanagerplugin/session/shellsession/shellsession_linux.go
@@ -1,0 +1,24 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//go:build linux
+// +build linux
+
+// Package shellsession starts shell session.
+package shellsession
+
+// disableDelayedSuspend is a no-op on Linux, which does not implement the DSUSP
+// (delayed suspend) terminal special character. The "dsusp" setting is rejected
+// by stty on Linux, so it must only be applied on BSD-derived systems. See the
+// BSD implementation and https://github.com/aws/session-manager-plugin/issues/29.
+func (s *ShellSession) disableDelayedSuspend() {}

--- a/src/sessionmanagerplugin/session/shellsession/shellsession_unix.go
+++ b/src/sessionmanagerplugin/session/shellsession/shellsession_unix.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/aws/session-manager-plugin/src/log"
@@ -34,6 +35,7 @@ func (s *ShellSession) disableEchoAndInputBuffering() {
 	getState(&s.originalSttyState)
 	setState(bytes.NewBufferString("cbreak"))
 	setState(bytes.NewBufferString("-echo"))
+	s.disableDelayedSuspend()
 }
 
 // getState gets current state of terminal
@@ -44,9 +46,12 @@ func getState(state *bytes.Buffer) error {
 	return cmd.Run()
 }
 
-// setState sets the new settings to terminal
+// setState sets the new settings to terminal. The buffer may contain several
+// whitespace-separated stty operands (for example "dsusp undef"), which must be
+// passed to stty as individual arguments rather than a single operand.
 func setState(state *bytes.Buffer) error {
-	cmd := exec.Command("stty", state.String())
+	args := strings.Fields(state.String())
+	cmd := exec.Command("stty", args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	return cmd.Run()


### PR DESCRIPTION
## Issue

Fixes #29

On BSD-derived systems, including macOS, pressing **Ctrl+Y** while a shell / SSM
session is connected terminates the session with:

```
Cannot perform start session: read /dev/stdin: resource temporarily unavailable
```

This also affects `aws ecs execute-command --interactive`, which uses Session
Manager under the hood. Linux and Windows are not affected.

## Root cause

`disableEchoAndInputBuffering` puts the terminal into `cbreak -echo`, but on BSD
terminals the driver still acts on the **DSUSP** (delayed suspend) special
character, whose default binding is Ctrl+Y. When pressed, the kernel performs a
delayed suspend and the plugin's `Stdin` read fails with `EAGAIN`
("resource temporarily unavailable"), which tears down the session.

The documented workaround in #29 is to run `stty dsusp undef` locally before
connecting. This PR applies the equivalent setting from within the plugin.

## Change

- Add a per-OS `disableDelayedSuspend()`:
  - **darwin / freebsd / netbsd / openbsd** (`shellsession_bsd.go`): runs
    `stty dsusp undef`.
  - **linux** (`shellsession_linux.go`): no-op, because Linux does not implement
    DSUSP and `stty` rejects the `dsusp` operand.
- Call it from `disableEchoAndInputBuffering` (BSD/macOS only).
- `setState` now splits its buffer with `strings.Fields`, so multi-token operands
  such as `dsusp undef` are passed to `stty` as separate arguments. Existing
  callers pass single tokens (`cbreak`, `-echo`, `echo`, and the `stty -g` blob),
  so their behavior is unchanged.

Windows is untouched (separate `shellsession_windows.go`).

## Testing

- `go build` for linux, darwin (amd64/arm64), freebsd, netbsd, openbsd — all pass.
- `go vet` and `gofmt` clean.
- `go test ./src/sessionmanagerplugin/session/shellsession/` passes.

## Licensing

I confirm this contribution is made under the terms of the Apache 2.0 license.
